### PR TITLE
盤面上に交互にOとXを表示できる機能を追加

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,24 +1,47 @@
-function Square({ value }) {
-  return <button className="square">{value}</button>;
+import { useState } from 'react';
+
+function Square({ value, onSquareClick }) {
+  return (
+    <button className="square" onClick={onSquareClick}>
+      {value}
+    </button>
+  );
 }
 
 export default function Board() {
+  const [xIsNext, setIsNext] = useState(true);
+  const [squares, setSquares] = useState(Array(9).fill(null));
+
+  function handleClick(i) {
+    if (squares[i]) {
+      return;
+    }
+    const nextSquares = squares.slice();
+    if (xIsNext) {
+      nextSquares[i] = "X";
+    } else {
+      nextSquares[i] = "O";
+    }
+    setSquares(nextSquares);
+    setIsNext(!xIsNext);
+  }
+
   return (
     <>
       <div className="board-row">
-       <Square/>
-       <Square/>
-       <Square/>
+        <Square value={squares[0]} onSquareClick={() => handleClick(0)} />
+        <Square value={squares[1]} onSquareClick={() => handleClick(1)} />
+        <Square value={squares[2]} onSquareClick={() => handleClick(2)} />
       </div>
       <div className="board-row">
-       <Square/>
-       <Square/>
-       <Square/>
+        <Square value={squares[3]} onSquareClick={() => handleClick(3)} />
+        <Square value={squares[4]} onSquareClick={() => handleClick(4)} />
+        <Square value={squares[5]} onSquareClick={() => handleClick(5)} />
       </div>
       <div className="board-row">
-       <Square/>
-       <Square/>
-       <Square/>
+        <Square value={squares[6]} onSquareClick={() => handleClick(6)} />
+        <Square value={squares[7]} onSquareClick={() => handleClick(7)} />
+        <Square value={squares[8]} onSquareClick={() => handleClick(8)} />
       </div>
     </>
   );


### PR DESCRIPTION
**概要**
プレイヤーのターンに応じて、3×3の盤面にX/Oを交互に表示する機能を実装しました。

**詳細**
- Boardコンポーネントで9マスを表すstate（squares）を管理。
- Squareコンポーネントに value / onClick を props 経由で渡すよう変更。
- クリック時にstateを更新し、"X"と"O"を交互に表示。
- プレイヤーの手番管理用に xIsNext を state に追加し、交互にマークが切り替わるように実装。
- 同じマスが2回押せないように早期returnを追加。

レビューをお願いします。

**UI**
| Before | After |
|--------|-------|
|<img width="320" height="317" alt="image" src="https://github.com/user-attachments/assets/1d8ba14e-c8cc-4a76-b99e-ecfa6ad3af77" />|<img width="516" height="528" alt="image" src="https://github.com/user-attachments/assets/93599720-697a-40e1-bc7e-5191fbf24987" />

今後は、勝者が決まった際やこれ以上ゲームを進められなくなった際に、適切なメッセージやUI表示を行う機能の実装を予定しています。
