### PR TITLE
盤面サイズを選択できるUIを追加

### DIFF
--- a/src/components/Board.jsx
+++ b/src/components/Board.jsx
@@ -1,17 +1,23 @@
 import { useState } from "react";
 import Square from "./Square";
+import SizeSelector from "./SizeSelector";
 import { calculateWinner } from "../utils/calculateWinner";
 
-const BOARD_WIDTH = 6;
-const BOARD_HEIGHT = 4;
+const MIN_SIZE = 3;
+const MAX_SIZE = 10;
+
+function createEmptyBoard(width, height) {
+  return Array.from({ length: height }, () => Array(width).fill(null));
+}
 
 export default function Board() {
+  const [width, setWidth] = useState(MIN_SIZE);
+  const [height, setHeight] = useState(MIN_SIZE);
   const [currentPlayer, setCurrentPlayer] = useState("X");
-  const [squares, setSquares] = useState(
-    Array.from({ length: BOARD_HEIGHT }, () => Array(BOARD_WIDTH).fill(null)),
-  );
+  const [squares, setSquares] = useState(createEmptyBoard(MIN_SIZE, MIN_SIZE));
 
-  const winner = calculateWinner(squares, BOARD_WIDTH, BOARD_HEIGHT);
+  const sizeOptions = Array.from({ length: MAX_SIZE - MIN_SIZE + 1 }, (_, i) => MIN_SIZE + i);
+  const winner = calculateWinner(squares, width, height);
   const isDraw = squares.flat().every((square) => square !== null) && !winner;
 
   const status = winner
@@ -23,10 +29,17 @@ export default function Board() {
   function handleClick(row, col) {
     if (squares[row][col] || winner) return;
 
-    const nextSquares = squares.map((r) => [...r]);
+    const nextSquares = squares.map((row) => [...row]);
     nextSquares[row][col] = currentPlayer;
     setSquares(nextSquares);
     setCurrentPlayer(currentPlayer === "X" ? "O" : "X");
+  }
+
+  function handleSizeChange(newWidth, newHeight) {
+    setWidth(newWidth);
+    setHeight(newHeight);
+    setCurrentPlayer("X");
+    setSquares(createEmptyBoard(newWidth, newHeight));
   }
 
   function renderRow(rowIndex) {
@@ -44,9 +57,12 @@ export default function Board() {
   }
 
   return (
-    <div className="board">
+    <div className="board-container">
+      <SizeSelector width={width} height={height} sizeOptions={sizeOptions} onSizeChange={handleSizeChange} />
+
       <div className="status">{status}</div>
-      {Array.from({ length: BOARD_HEIGHT }, (_, row) => renderRow(row))}
+
+      <div className="board">{Array.from({ length: height }, (_, row) => renderRow(row))}</div>
     </div>
   );
 }

--- a/src/components/SizeSelector.jsx
+++ b/src/components/SizeSelector.jsx
@@ -1,0 +1,33 @@
+export default function SizeSelector({ width, height, sizeOptions, onSizeChange }) {
+  const parseValue = (e) => parseInt(e.target.value, 10);
+
+  const handleWidthChange = (e) => {
+    const newWidth = parseValue(e);
+    onSizeChange(newWidth, height);
+  };
+
+  const handleHeightChange = (e) => {
+    const newHeight = parseValue(e);
+    onSizeChange(width, newHeight);
+  };
+
+  const renderSelect = (label, value, onChange, keyPrefix) => (
+    <label>
+      {label}:
+      <select value={value} onChange={onChange}>
+        {sizeOptions.map((val) => (
+          <option key={`${keyPrefix}-${val}`} value={val}>
+            {val}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+
+  return (
+    <div className="controls">
+      {renderSelect('Width', width, handleWidthChange, 'w')}
+      {renderSelect('Height', height, handleHeightChange, 'h')}
+    </div>
+  );
+}


### PR DESCRIPTION
UI上で値を変えることで盤面サイズ（高さ・幅）を変更できるようにしました。

詳細
- SizeSelectorコンポーネントで、幅・高さを3〜10の範囲で選択可能にしました
- 選択したサイズに応じて、盤面が即時リセット＆更新されるようにしています
- デフォルトは 3x3 の盤面です

<img width="229" height="205" alt="image" src="https://github.com/user-attachments/assets/728fc097-7e34-4dc1-8287-b278a06eabc9" />

